### PR TITLE
Docs: API - Remove duplicate lines in ****InfiniteGridOptions

### DIFF
--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/FrameInfiniteGridOptions.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/FrameInfiniteGridOptions.mdx
@@ -31,22 +31,6 @@ custom_edit_url: null
 |frame|number[][]|Grid의 모양. 2d 배열([contentPos][inlinePos])로 아이템의 모양과 순서를 설정할 수 있다. 숫자로 배열을 채운만큼 아이템을 배치할 수 있으며 0과 공백은 빈 공간이다. 아이템들의 순서는 배열을 채운 숫자값의 오름차순대로 배치가 된다. (default: [])|
 |useFrameFill|boolean| 다음 프레임이 전 프레임에 이어 붙일 수 있는지 있는지 확인한다.|
 |rectSize|number \| {inlineSize: number, contentSize: number}|1x1 직사각형 크기. 0이면 frame의 column의 개수에 의해 결정된다. (default: 0)|
-|horizontal|boolean|스크롤 이동 방향. (true: 가로방향, false: 세로방향) horizontal이 false 면 <code>inlinePos</code>는 left, <code>inlineSize</code>는 width, <code>contentPos</code>는 top, <code>contentSize</code>는 height다. horizontal이 true면 <code>inlinePos</code>는 top, <code>inlineSize</code>는 height, <code>contentPos</code>는 left, <code>contentSize</code>는 width이다. (default: false)|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|item의 css size와 position를 %로 설정할지 여부.|
-|isEqualSize|boolean|카드 엘리먼트의 크기가 동일한지 여부. 배치될 카드 엘리먼트의 크기가 모두 동일할 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|isConstantSize|boolean|모든 카드 엘리먼트의 크기가 불변일 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|gap|number|아이템들 사이의 공간. (default: 5)|
-|attributePrefix|string|엘리먼트의 데이타 속성에 사용할 접두사. (default: &quot;data-grid-&quot;)|
-|resizeDebounce|number|리사이즈 이벤트에 설정할 디바운스 시간. (default: 100)|
-|maxResizeDebounce|number|리사이즈 이벤트를 디바운스할 수 있는 최대 시간(0은 미설정이다). (default: 0)|
-|autoResize|boolean|렌더링시 상단이 비어있을 때 아웃라인을 0으로 이동시킬지 여부. 하지만 상단보다 넘치는 경우 아웃라인을 0으로 강제 이동한다. (default: true)|
-|useFit|boolean|window의 resize 이벤트 이후 자동으로 resize()메소드를 호출할지의 여부. (default: true)|
-|useTransform|boolean|left, top css 속성 쓰는 대신 transform 속성을 사용할지 여부.|
-|renderOnPropertyChange|boolean|property의 변화를 통해 자동으로 render를 할지 여부.|
-|preserveUIOnDestroy|boolean|destroy 시 기존 컨테이너, 아이템의 UI를 보존할지 여부.|
-|defaultDirection|"start" \| "end"|render옵션에서 direction을 미설정시의 기본 방향값.|
-|externalItemRenderer|ItemRenderer \| null|외부에서 직접 ItemRenderer를 설정할 수 있다.|
-|externalContainerManager|ContainerManager \| null|외부에서 직접 ContainerManager를 설정할 수 있다.|
 |container|boolean \| string \| HTMLElement|container를 적용할 대상. false면 자기 자신, true면 container를 생성. string 또는 HTMLElement는 직접 대상을 지정. (default: false)|
 |containerTag|string|container를 생성한다면 container의 tag를 정할 수 있다. (default: &quot;div&quot;)|
 |threshold|number|다음 아이템 그룹을 추가하기 위한 스크롤 영역의 크기. (default: 100)|

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/JustifiedInfiniteGridOptions.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/JustifiedInfiniteGridOptions.mdx
@@ -33,22 +33,6 @@ custom_edit_url: null
 |sizeRange|number \| number[]|아이템이 조정되는 최소, 최대 사이즈. 계산이 되지 않는 경우 최소, 최대 사이즈를 벗어날 수 있다. (default: [0, Infinity])|
 |displayedRow|number|컨테이너 크기에 계산될 최대 row 개수. overflow: hidden을 설정하면 화면에 가릴 수 있다. -1은 미설정이다. (default: -1)|
 |isCroppedSize|boolean|row사이즈가 sizeRange에 벗어나면 크롭할지 여부. true로 설정하면 비율이 깨질 수 있다. (default: false)|
-|horizontal|boolean|스크롤 이동 방향. (true: 가로방향, false: 세로방향) horizontal이 false 면 <code>inlinePos</code>는 left, <code>inlineSize</code>는 width, <code>contentPos</code>는 top, <code>contentSize</code>는 height다. horizontal이 true면 <code>inlinePos</code>는 top, <code>inlineSize</code>는 height, <code>contentPos</code>는 left, <code>contentSize</code>는 width이다. (default: false)|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|item의 css size와 position를 %로 설정할지 여부.|
-|isEqualSize|boolean|카드 엘리먼트의 크기가 동일한지 여부. 배치될 카드 엘리먼트의 크기가 모두 동일할 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|isConstantSize|boolean|모든 카드 엘리먼트의 크기가 불변일 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|gap|number|아이템들 사이의 공간. (default: 5)|
-|attributePrefix|string|엘리먼트의 데이타 속성에 사용할 접두사. (default: &quot;data-grid-&quot;)|
-|resizeDebounce|number|리사이즈 이벤트에 설정할 디바운스 시간. (default: 100)|
-|maxResizeDebounce|number|리사이즈 이벤트를 디바운스할 수 있는 최대 시간(0은 미설정이다). (default: 0)|
-|autoResize|boolean|렌더링시 상단이 비어있을 때 아웃라인을 0으로 이동시킬지 여부. 하지만 상단보다 넘치는 경우 아웃라인을 0으로 강제 이동한다. (default: true)|
-|useFit|boolean|window의 resize 이벤트 이후 자동으로 resize()메소드를 호출할지의 여부. (default: true)|
-|useTransform|boolean|left, top css 속성 쓰는 대신 transform 속성을 사용할지 여부.|
-|renderOnPropertyChange|boolean|property의 변화를 통해 자동으로 render를 할지 여부.|
-|preserveUIOnDestroy|boolean|destroy 시 기존 컨테이너, 아이템의 UI를 보존할지 여부.|
-|defaultDirection|"start" \| "end"|render옵션에서 direction을 미설정시의 기본 방향값.|
-|externalItemRenderer|ItemRenderer \| null|외부에서 직접 ItemRenderer를 설정할 수 있다.|
-|externalContainerManager|ContainerManager \| null|외부에서 직접 ContainerManager를 설정할 수 있다.|
 |container|boolean \| string \| HTMLElement|container를 적용할 대상. false면 자기 자신, true면 container를 생성. string 또는 HTMLElement는 직접 대상을 지정. (default: false)|
 |containerTag|string|container를 생성한다면 container의 tag를 정할 수 있다. (default: &quot;div&quot;)|
 |threshold|number|다음 아이템 그룹을 추가하기 위한 스크롤 영역의 크기. (default: 100)|

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/MasonryInfiniteGridOptions.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/MasonryInfiniteGridOptions.mdx
@@ -32,22 +32,6 @@ custom_edit_url: null
 |columnSize|number| 열의 사이즈. 만약 열의 사이즈가 0이면, 아이템들의 첫번째 아이템의 사이즈로 계산이 된다. (default: 0) |
 |columnSizeRatio|number|열의 사이즈 비율(inlineSize / contentSize). 0은 미설정이다. |
 |align|GridAlign|아이템들의 위치의 정렬. <code>stretch</code>를 사용하고 싶다면 <code>column</code> 또는 <code>columnSize</code> 옵션을 설정해라.  (&quot;start&quot;, &quot;center&quot;, &quot;end&quot;, &quot;justify&quot;, &quot;stretch&quot;) (default: &quot;justify&quot;)|
-|horizontal|boolean|스크롤 이동 방향. (true: 가로방향, false: 세로방향) horizontal이 false 면 <code>inlinePos</code>는 left, <code>inlineSize</code>는 width, <code>contentPos</code>는 top, <code>contentSize</code>는 height다. horizontal이 true면 <code>inlinePos</code>는 top, <code>inlineSize</code>는 height, <code>contentPos</code>는 left, <code>contentSize</code>는 width이다. (default: false)|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|item의 css size와 position를 %로 설정할지 여부.|
-|isEqualSize|boolean|카드 엘리먼트의 크기가 동일한지 여부. 배치될 카드 엘리먼트의 크기가 모두 동일할 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|isConstantSize|boolean|모든 카드 엘리먼트의 크기가 불변일 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|gap|number|아이템들 사이의 공간. (default: 5)|
-|attributePrefix|string|엘리먼트의 데이타 속성에 사용할 접두사. (default: &quot;data-grid-&quot;)|
-|resizeDebounce|number|리사이즈 이벤트에 설정할 디바운스 시간. (default: 100)|
-|maxResizeDebounce|number|리사이즈 이벤트를 디바운스할 수 있는 최대 시간(0은 미설정이다). (default: 0)|
-|autoResize|boolean|렌더링시 상단이 비어있을 때 아웃라인을 0으로 이동시킬지 여부. 하지만 상단보다 넘치는 경우 아웃라인을 0으로 강제 이동한다. (default: true)|
-|useFit|boolean|window의 resize 이벤트 이후 자동으로 resize()메소드를 호출할지의 여부. (default: true)|
-|useTransform|boolean|left, top css 속성 쓰는 대신 transform 속성을 사용할지 여부.|
-|renderOnPropertyChange|boolean|property의 변화를 통해 자동으로 render를 할지 여부.|
-|preserveUIOnDestroy|boolean|destroy 시 기존 컨테이너, 아이템의 UI를 보존할지 여부.|
-|defaultDirection|"start" \| "end"|render옵션에서 direction을 미설정시의 기본 방향값.|
-|externalItemRenderer|ItemRenderer \| null|외부에서 직접 ItemRenderer를 설정할 수 있다.|
-|externalContainerManager|ContainerManager \| null|외부에서 직접 ContainerManager를 설정할 수 있다.|
 |container|boolean \| string \| HTMLElement|container를 적용할 대상. false면 자기 자신, true면 container를 생성. string 또는 HTMLElement는 직접 대상을 지정. (default: false)|
 |containerTag|string|container를 생성한다면 container의 tag를 정할 수 있다. (default: &quot;div&quot;)|
 |threshold|number|다음 아이템 그룹을 추가하기 위한 스크롤 영역의 크기. (default: 100)|

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/PackingInfiniteGridOptions.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/PackingInfiniteGridOptions.mdx
@@ -32,22 +32,6 @@ custom_edit_url: null
 |sizeWeight|number|아이템들을 배치하는데 사이즈 가중치. (default: 1)|
 |ratioWeight|number|아이템들을 배치하는데 비율을 유지하는 가중치. (default: 1)|
 |weightPriority|"size" \| "ratio" \| "custom"| 아이템의 가중치를 결정하는 우선수치. (default: &quot;custom&quot;), &quot;size&quot; = (sizeWieght: 100, ratioWeight: 1), &quot;ratio&quot; = (sizeWeight: 1, ratioWeight; 100), &quot;custom&quot; = (set sizeWeight, ratioWeight). 아이템의 가중치 = ratio(inlineSize / contentSize)의 변화량 * <code>ratioWeight</code> + size(inlineSize * contentSize)의 변화량 * <code>sizeWeight</code>.|
-|horizontal|boolean|스크롤 이동 방향. (true: 가로방향, false: 세로방향) horizontal이 false 면 <code>inlinePos</code>는 left, <code>inlineSize</code>는 width, <code>contentPos</code>는 top, <code>contentSize</code>는 height다. horizontal이 true면 <code>inlinePos</code>는 top, <code>inlineSize</code>는 height, <code>contentPos</code>는 left, <code>contentSize</code>는 width이다. (default: false)|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|item의 css size와 position를 %로 설정할지 여부.|
-|isEqualSize|boolean|카드 엘리먼트의 크기가 동일한지 여부. 배치될 카드 엘리먼트의 크기가 모두 동일할 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|isConstantSize|boolean|모든 카드 엘리먼트의 크기가 불변일 때 이 옵션을 'true'로 설정하면 레이아웃 배치 성능을 높일 수 있다. (default: false)|
-|gap|number|아이템들 사이의 공간. (default: 5)|
-|attributePrefix|string|엘리먼트의 데이타 속성에 사용할 접두사. (default: &quot;data-grid-&quot;)|
-|resizeDebounce|number|리사이즈 이벤트에 설정할 디바운스 시간. (default: 100)|
-|maxResizeDebounce|number|리사이즈 이벤트를 디바운스할 수 있는 최대 시간(0은 미설정이다). (default: 0)|
-|autoResize|boolean|렌더링시 상단이 비어있을 때 아웃라인을 0으로 이동시킬지 여부. 하지만 상단보다 넘치는 경우 아웃라인을 0으로 강제 이동한다. (default: true)|
-|useFit|boolean|window의 resize 이벤트 이후 자동으로 resize()메소드를 호출할지의 여부. (default: true)|
-|useTransform|boolean|left, top css 속성 쓰는 대신 transform 속성을 사용할지 여부.|
-|renderOnPropertyChange|boolean|property의 변화를 통해 자동으로 render를 할지 여부.|
-|preserveUIOnDestroy|boolean|destroy 시 기존 컨테이너, 아이템의 UI를 보존할지 여부.|
-|defaultDirection|"start" \| "end"|render옵션에서 direction을 미설정시의 기본 방향값.|
-|externalItemRenderer|ItemRenderer \| null|외부에서 직접 ItemRenderer를 설정할 수 있다.|
-|externalContainerManager|ContainerManager \| null|외부에서 직접 ContainerManager를 설정할 수 있다.|
 |container|boolean \| string \| HTMLElement|container를 적용할 대상. false면 자기 자신, true면 container를 생성. string 또는 HTMLElement는 직접 대상을 지정. (default: false)|
 |containerTag|string|container를 생성한다면 container의 tag를 정할 수 있다. (default: &quot;div&quot;)|
 |threshold|number|다음 아이템 그룹을 추가하기 위한 스크롤 영역의 크기. (default: 100)|

--- a/docs/versioned_docs/version-4.1.1/api/FrameInfiniteGridOptions.mdx
+++ b/docs/versioned_docs/version-4.1.1/api/FrameInfiniteGridOptions.mdx
@@ -31,22 +31,6 @@ custom_edit_url: null
 |frame|number[][]|<p>The shape of the grid. You can set the shape and order of items with a 2d array ([contentPos][inlinePos]). You can place items as many times as you fill the array with numbers, and zeros and spaces are empty spaces. The order of the items is arranged in ascending order of the numeric values that fill the array. (default: [])<br /></p>|
 |useFrameFill|boolean|<p>Make sure that the frame can be attached after the previous frame. (default: true) </p>|
 |rectSize|number \| {inlineSize: number, contentSize: number}|<p>1x1 rect size. If it is 0, it is determined by the number of columns in the frame. (default: 0) </p>|
-|horizontal|boolean|<p>Direction of the scroll movement. (true: horizontal, false: vertical) If horizontal is false, <code>inlinePos</code> is left, <code>inlineSize</code> is width, <code>contentPos</code> is top, and <code>contentSize</code> is height. If horizontal is true, <code>inlinePos</code> is top, <code>inlineSize</code> is height, <code>contentPos</code> is left, and <code>contentSize</code> is width.  (default: false)<br /></p>|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|<p>Whether to set the css size and position of the item to %. (default: false)</p>|
-|isEqualSize|boolean|<p>Indicates whether sizes of all card elements are equal to one another. If sizes of card elements to be arranged are all equal and this option is set to &quot;true&quot;, the performance of layout arrangement can be improved. (default: false)</p>|
-|isConstantSize|boolean|<p>Indicates whether sizes of all card elements does not change, the performance of layout arrangement can be improved. (default: false)</p>|
-|gap|number|<p>Gap used to create space around items. (default: 5)</p>|
-|attributePrefix|string|<p>The prefix to use element's data attribute. (default: &quot;data-grid-&quot;)</p>|
-|resizeDebounce|number|<p>Debounce time to set in the resize event. (default: 100)</p>|
-|maxResizeDebounce|number|<p>Maximum time to debounce the resize event(0 is not set). (default: 0)</p>|
-|autoResize|boolean|<p>Whether to move the outline to 0 when the top is empty when rendering. However, if it overflows above the top, the outline is forced to 0. (default: true) </p>|
-|useFit|boolean|<p>Whether the resize method should be called automatically after a window resize event. (default: true)</p>|
-|useTransform|boolean|<p>Whether to use transform property instead of using left and top css properties. </p>|
-|renderOnPropertyChange|boolean|<p>Whether to automatically render through property change. </p>|
-|preserveUIOnDestroy|boolean|<p>Whether to preserve the UI of the existing container or item when destroying. </p>|
-|defaultDirection|"start" \| "end"|<p>The default direction value when direction is not set in the render option. </p>|
-|externalItemRenderer|ItemRenderer \| null|<p>You can set the ItemRenderer directly externally. </p>|
-|externalContainerManager|ContainerManager \| null|<p>You can set the ContainerManager를 directly externally. </p>|
 |container|boolean \| string \| HTMLElement|<p>The target to which the container is applied. If false, create itself, if true, create container. A string or HTMLElement specifies the target directly. (default: false) </p>|
 |containerTag|string|<p>If you create a container, you can set the container's tag. (default: &quot;div&quot;) </p>|
 |threshold|number|<p>The size of the scrollable area for adding the next group of items. (default: 100) </p>|

--- a/docs/versioned_docs/version-4.1.1/api/JustifiedInfiniteGridOptions.mdx
+++ b/docs/versioned_docs/version-4.1.1/api/JustifiedInfiniteGridOptions.mdx
@@ -33,22 +33,6 @@ custom_edit_url: null
 |sizeRange|number \| number[]|<p>The minimum and maximum size by which the item is adjusted. If it is not calculated, it may deviate from the minimum and maximum sizes. (default: [0, Infinity]) </p>|
 |displayedRow|number|<p>Maximum number of rows to be counted for container size. You can hide it on the screen by setting overflow: hidden. -1 is not set. (default: -1)</p>|
 |isCroppedSize|boolean|<p>Whether to crop when the row size is out of sizeRange. If set to true, this ratio can be broken. (default: false) </p>|
-|horizontal|boolean|<p>Direction of the scroll movement. (true: horizontal, false: vertical) If horizontal is false, <code>inlinePos</code> is left, <code>inlineSize</code> is width, <code>contentPos</code> is top, and <code>contentSize</code> is height. If horizontal is true, <code>inlinePos</code> is top, <code>inlineSize</code> is height, <code>contentPos</code> is left, and <code>contentSize</code> is width.  (default: false)<br /></p>|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|<p>Whether to set the css size and position of the item to %. (default: false)</p>|
-|isEqualSize|boolean|<p>Indicates whether sizes of all card elements are equal to one another. If sizes of card elements to be arranged are all equal and this option is set to &quot;true&quot;, the performance of layout arrangement can be improved. (default: false)</p>|
-|isConstantSize|boolean|<p>Indicates whether sizes of all card elements does not change, the performance of layout arrangement can be improved. (default: false)</p>|
-|gap|number|<p>Gap used to create space around items. (default: 5)</p>|
-|attributePrefix|string|<p>The prefix to use element's data attribute. (default: &quot;data-grid-&quot;)</p>|
-|resizeDebounce|number|<p>Debounce time to set in the resize event. (default: 100)</p>|
-|maxResizeDebounce|number|<p>Maximum time to debounce the resize event(0 is not set). (default: 0)</p>|
-|autoResize|boolean|<p>Whether to move the outline to 0 when the top is empty when rendering. However, if it overflows above the top, the outline is forced to 0. (default: true) </p>|
-|useFit|boolean|<p>Whether the resize method should be called automatically after a window resize event. (default: true)</p>|
-|useTransform|boolean|<p>Whether to use transform property instead of using left and top css properties. </p>|
-|renderOnPropertyChange|boolean|<p>Whether to automatically render through property change. </p>|
-|preserveUIOnDestroy|boolean|<p>Whether to preserve the UI of the existing container or item when destroying. </p>|
-|defaultDirection|"start" \| "end"|<p>The default direction value when direction is not set in the render option. </p>|
-|externalItemRenderer|ItemRenderer \| null|<p>You can set the ItemRenderer directly externally. </p>|
-|externalContainerManager|ContainerManager \| null|<p>You can set the ContainerManager를 directly externally. </p>|
 |container|boolean \| string \| HTMLElement|<p>The target to which the container is applied. If false, create itself, if true, create container. A string or HTMLElement specifies the target directly. (default: false) </p>|
 |containerTag|string|<p>If you create a container, you can set the container's tag. (default: &quot;div&quot;) </p>|
 |threshold|number|<p>The size of the scrollable area for adding the next group of items. (default: 100) </p>|

--- a/docs/versioned_docs/version-4.1.1/api/MasonryInfiniteGridOptions.mdx
+++ b/docs/versioned_docs/version-4.1.1/api/MasonryInfiniteGridOptions.mdx
@@ -32,22 +32,6 @@ custom_edit_url: null
 |columnSize|number|<p>The size of the columns. If it is 0, it is calculated as the size of the first item in items. (default: 0) </p>|
 |columnSizeRatio|number|<p>The size ratio(inlineSize / contentSize) of the columns. 0 is not set. (default: 0) </p>|
 |align|GridAlign|<p>Align of the position of the items. If you want to use <code>stretch</code>, be sure to set <code>column</code> or <code>columnSize</code> option. (&quot;start&quot;, &quot;center&quot;, &quot;end&quot;, &quot;justify&quot;, &quot;stretch&quot;) (default: &quot;justify&quot;) </p>|
-|horizontal|boolean|<p>Direction of the scroll movement. (true: horizontal, false: vertical) If horizontal is false, <code>inlinePos</code> is left, <code>inlineSize</code> is width, <code>contentPos</code> is top, and <code>contentSize</code> is height. If horizontal is true, <code>inlinePos</code> is top, <code>inlineSize</code> is height, <code>contentPos</code> is left, and <code>contentSize</code> is width.  (default: false)<br /></p>|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|<p>Whether to set the css size and position of the item to %. (default: false)</p>|
-|isEqualSize|boolean|<p>Indicates whether sizes of all card elements are equal to one another. If sizes of card elements to be arranged are all equal and this option is set to &quot;true&quot;, the performance of layout arrangement can be improved. (default: false)</p>|
-|isConstantSize|boolean|<p>Indicates whether sizes of all card elements does not change, the performance of layout arrangement can be improved. (default: false)</p>|
-|gap|number|<p>Gap used to create space around items. (default: 5)</p>|
-|attributePrefix|string|<p>The prefix to use element's data attribute. (default: &quot;data-grid-&quot;)</p>|
-|resizeDebounce|number|<p>Debounce time to set in the resize event. (default: 100)</p>|
-|maxResizeDebounce|number|<p>Maximum time to debounce the resize event(0 is not set). (default: 0)</p>|
-|autoResize|boolean|<p>Whether to move the outline to 0 when the top is empty when rendering. However, if it overflows above the top, the outline is forced to 0. (default: true) </p>|
-|useFit|boolean|<p>Whether the resize method should be called automatically after a window resize event. (default: true)</p>|
-|useTransform|boolean|<p>Whether to use transform property instead of using left and top css properties. </p>|
-|renderOnPropertyChange|boolean|<p>Whether to automatically render through property change. </p>|
-|preserveUIOnDestroy|boolean|<p>Whether to preserve the UI of the existing container or item when destroying. </p>|
-|defaultDirection|"start" \| "end"|<p>The default direction value when direction is not set in the render option. </p>|
-|externalItemRenderer|ItemRenderer \| null|<p>You can set the ItemRenderer directly externally. </p>|
-|externalContainerManager|ContainerManager \| null|<p>You can set the ContainerManager를 directly externally. </p>|
 |container|boolean \| string \| HTMLElement|<p>The target to which the container is applied. If false, create itself, if true, create container. A string or HTMLElement specifies the target directly. (default: false) </p>|
 |containerTag|string|<p>If you create a container, you can set the container's tag. (default: &quot;div&quot;) </p>|
 |threshold|number|<p>The size of the scrollable area for adding the next group of items. (default: 100) </p>|

--- a/docs/versioned_docs/version-4.1.1/api/PackingInfiniteGridOptions.mdx
+++ b/docs/versioned_docs/version-4.1.1/api/PackingInfiniteGridOptions.mdx
@@ -32,22 +32,6 @@ custom_edit_url: null
 |sizeWeight|number|<p>The size weight when placing items. (default: 1)</p>|
 |ratioWeight|number|<p>The weight to keep ratio when placing items. (default: 1)</p>|
 |weightPriority|"size" \| "ratio" \| "custom"|<p>The priority that determines the weight of the item. (default: &quot;custom&quot;), &quot;size&quot; = (sizeWieght: 100, ratioWeight: 1), &quot;ratio&quot; = (sizeWeight: 1, ratioWeight; 100), &quot;custom&quot; = (set sizeWeight, ratioWeight)<br />item's weight = item's ratio(inlineSize / contentSize) change * <code>ratioWeight</code> + size(inlineSize * contentSize) change * <code>sizeWeight</code>.<br /></p>|
-|horizontal|boolean|<p>Direction of the scroll movement. (true: horizontal, false: vertical) If horizontal is false, <code>inlinePos</code> is left, <code>inlineSize</code> is width, <code>contentPos</code> is top, and <code>contentSize</code> is height. If horizontal is true, <code>inlinePos</code> is top, <code>inlineSize</code> is height, <code>contentPos</code> is left, and <code>contentSize</code> is width.  (default: false)<br /></p>|
-|percentage|Array&lt;"position" \| "size"&gt; \| boolean|<p>Whether to set the css size and position of the item to %. (default: false)</p>|
-|isEqualSize|boolean|<p>Indicates whether sizes of all card elements are equal to one another. If sizes of card elements to be arranged are all equal and this option is set to &quot;true&quot;, the performance of layout arrangement can be improved. (default: false)</p>|
-|isConstantSize|boolean|<p>Indicates whether sizes of all card elements does not change, the performance of layout arrangement can be improved. (default: false)</p>|
-|gap|number|<p>Gap used to create space around items. (default: 5)</p>|
-|attributePrefix|string|<p>The prefix to use element's data attribute. (default: &quot;data-grid-&quot;)</p>|
-|resizeDebounce|number|<p>Debounce time to set in the resize event. (default: 100)</p>|
-|maxResizeDebounce|number|<p>Maximum time to debounce the resize event(0 is not set). (default: 0)</p>|
-|autoResize|boolean|<p>Whether to move the outline to 0 when the top is empty when rendering. However, if it overflows above the top, the outline is forced to 0. (default: true) </p>|
-|useFit|boolean|<p>Whether the resize method should be called automatically after a window resize event. (default: true)</p>|
-|useTransform|boolean|<p>Whether to use transform property instead of using left and top css properties. </p>|
-|renderOnPropertyChange|boolean|<p>Whether to automatically render through property change. </p>|
-|preserveUIOnDestroy|boolean|<p>Whether to preserve the UI of the existing container or item when destroying. </p>|
-|defaultDirection|"start" \| "end"|<p>The default direction value when direction is not set in the render option. </p>|
-|externalItemRenderer|ItemRenderer \| null|<p>You can set the ItemRenderer directly externally. </p>|
-|externalContainerManager|ContainerManager \| null|<p>You can set the ContainerManager를 directly externally. </p>|
 |container|boolean \| string \| HTMLElement|<p>The target to which the container is applied. If false, create itself, if true, create container. A string or HTMLElement specifies the target directly. (default: false) </p>|
 |containerTag|string|<p>If you create a container, you can set the container's tag. (default: &quot;div&quot;) </p>|
 |threshold|number|<p>The size of the scrollable area for adding the next group of items. (default: 100) </p>|


### PR DESCRIPTION
Removed duplicate typedefs in both`/docs/i18n/ko/docusaurus-plugin-content-docs/version-4.1.1/api/` and `/docs/versioned_docs/4.1.1/` for the following files:

FrameInfiniteGridOptions.mdx
JustifiedInfiniteGridOptions.mdx
MasonryInfiniteGridOptions.mdx (already fixed in versioned_docs)
PackingInfiniteGridOptions.mdx

## Issue
#465

## Details
<!-- Detailed description of the change/feature -->
