### PR TITLE
Update index.d.ts

### DIFF
--- a/packages/svelte-infinitegrid/src/index.d.ts
+++ b/packages/svelte-infinitegrid/src/index.d.ts
@@ -3,7 +3,7 @@ import VanillaInfiniteGrid, {
   MasonryInfiniteGridOptions, PackingInfiniteGridOptions,
   InfiniteGridStatus,
 } from "@egjs/Infinitegrid";
-import { SvelteComponentDev } from "svelte/internal";
+import { SvelteComponent } from "svelte";
 
 export interface SveltInfiniteGridOptions {
   items?: any[];
@@ -16,7 +16,7 @@ export interface SveltInfiniteGridOptions {
   infoBy?: (item: any, index: number) => Record<string, any>;
 }
 
-export default abstract class InfiniteGrid<T extends InfiniteGridOptions> extends SvelteComponentDev {
+export default abstract class InfiniteGrid<T extends InfiniteGridOptions> extends SvelteComponent {
   $$prop_def: Record<string, any> & SveltInfiniteGridOptions & T;
   getInstance(): VanillaInfiniteGrid;
 }


### PR DESCRIPTION
###### Issue

Svelte 4 produces the type error "Type definitions are missing for this Svelte Component. If you are using Svelte 3.31+, use SvelteComponentTyped to add a definition"  

###### Change

Replaced SvelteComponentDev with SvelteComponent 
